### PR TITLE
UFORGE-4115 documentation: migration needs major versions

### DIFF
--- a/admin/en/source/pages/config/populate-db-OS.rst
+++ b/admin/en/source/pages/config/populate-db-OS.rst
@@ -13,7 +13,9 @@ To enable UForge to generate images based on the operating system it needs all t
 
 For information specific about Windows, refer to :ref:`first-windows-install`.
 
-.. note:: When installing a major version, all minor versions will be included. If you want to restrict to only a few minor versions, you will have to follow this procedure for each minor version you want to install.
+.. note:: When installing a major version, all minor versions will be included. If you want to restrict to only a few minor versions, you will have to follow this procedure for each minor version you want to install.  
+
+.. warning:: If you are going to use the migration feature for RHEL or CentOS, then it is highly recommended to register the major version repositories.
 
 In order to add an operation system in your UForge AppCenter you must:
 

--- a/admin/en/source/pages/upgrade/upgrade-overview.rst
+++ b/admin/en/source/pages/upgrade/upgrade-overview.rst
@@ -108,8 +108,12 @@ The RPM packages will be replaced and the services will be reconfigured to corre
 	.. code-block:: shell
 
 		# service squid status
-		squid is stopped
-		// if squid is stopped, run the following command-line
+		
+	
+	If squid is stopped, run the following command-line
+	
+	.. code-block:: shell
+
 		# service squid start	
 
 .. _retrieve-data:
@@ -150,7 +154,7 @@ The following is an example of a request sent to an UForge AppCenter with hostna
 
 .. code-block:: shell
 
-	$ curl 'http://10.0.0.20:9090/ufws/users/myUser -H "Authorization: Basic myUser:password" -H "Accept: application/xml" -v | tidy -xml -indent -quiet
+	$ curl "http://10.0.0.20:9090/ufws/users/myUser" -H "Authorization: Basic myUser:password" -H "Accept: application/xml" -v | tidy -xml -indent -quiet
 
 		* About to connect() to 10.0.0.20 port 8080 (#0)
 		* Trying 10.0.0.20... connected


### PR DESCRIPTION
- Admin Guide: Added warning, that for migration major versions of RHEL and CentOS should be populated
- Fixed shell script parser warning