### PR TITLE
UFORGE-4979 Cli documentation has meaningless red or blue color

### DIFF
--- a/admin/en/source/pages/tools/cli-overview.rst
+++ b/admin/en/source/pages/tools/cli-overview.rst
@@ -17,9 +17,7 @@ The UForge AppCenter command-line tool has the form:
 
 Usage: uforge <target> <command> [options][args]
 
-Where <target> is one of the following:
-
-.. code-block:: shell
+Where <target> is one of the following::
 
   entitlement           Administration of all the entitlements in UForge for
                         RBAC


### PR DESCRIPTION
- no longer using code block for this, rather just text (as it contains ' characters, which is interpreted)