### PR TITLE
UFORGE-4839 Windows Core Edition golden images minimal size must be 12GB instead of 9GB

### DIFF
--- a/admin/en/source/pages/rebranding/custo-footer.rst
+++ b/admin/en/source/pages/rebranding/custo-footer.rst
@@ -18,14 +18,6 @@ The version number is automatically provided as part of the initial configuratio
 
 For colours and layout modifications, please refer to :ref:`customize-css`.
 
-Hiding the UForge URL
-~~~~~~~~~~~~~~~~~~~~~
-
-To show or hide the UForge URL, under ``<c:client>`` enter “false” if you do not want to show the URL:
-
-.. code-block:: xml 
-
-	<c:showUForgeUrl>false</c:showUForgeUrl>
 
 Modifying the Copyright
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/end-user/en/source/pages/templating/appliance-advanced-partition.rst
+++ b/end-user/en/source/pages/templating/appliance-advanced-partition.rst
@@ -76,7 +76,7 @@ You can set an advanced partioning table for a Windows based appliance template.
 	2. Click on the green + sign at the top.
 	3. You can modify the name and partitions type
 	4. Select the filesystem to ``ntfs`` and mount point, for example: ``D:``.
-	5. Enter the size. The install disk should be ``12 Gb`` for core versions and not less than ``32Gb`` for the full version
+	5. Enter the size. The install disk should be at least ``14 Gb`` for core versions and ``20Gb`` for full versions
 	6. Check the box in the ``Grow`` column if you want the partition to be growable.
 	7. Click ``save``.
 

--- a/end-user/en/source/pages/templating/appliance-generate.rst
+++ b/end-user/en/source/pages/templating/appliance-generate.rst
@@ -18,7 +18,7 @@ To generate a machine image:
 
 	6. You can set the disk size, then click the ``generate`` button to launch a generation in UForge for this appliance template. 
 
-		.. note:: Depending on the packages you install and the size of your software, make sure that the disk size is large enough to accommodate the software to be installed.
+		.. note:: Depending on the packages you install and the size of your software, make sure that the disk size is large enough to accommodate the software to be installed.  For windows based operating systems, it is advised to have a disk size of at least ``14GB`` for core versions, and at least ``20GB`` for full versions.
 
 
 The generation will take a few minutes to complete (depending on the number of packages in the appliance template and the disk size chosen). The generation progress is shown.

--- a/end-user/en/source/pages/templating/appliance-installprofile.rst
+++ b/end-user/en/source/pages/templating/appliance-installprofile.rst
@@ -20,6 +20,8 @@ You can define the following as part of the install profile:
 * ``Welcome Message``: You can enter a welcome message.
 * ``Services``: You to activate or deactivate the firewall present in the filesystem when launching the appliance (regardless of whether the firewall is iptables or other). Firewall is set to ``Off`` by default. 
 
+.. note:: For basic partitioning disk size, you must ensure that the disk is large enough to store all the binaries and files for the appliance template.  For windows based operating systems, it is advised to have a disk size of at least ``14GB`` for core versions, and at least ``20GB`` for  full versions.
+
 .. _appliance-install-profile-users-groups:
 
 Adding Users and Groups


### PR DESCRIPTION
Updated the docs i the install profile and generation sections to warn users on the disk size they are choosing, specifically Windows based os appliance templates.  Providing minimal disk size guidelines for "core" and "full" windows versions.