### PR TITLE
UFORGE-4587 migration breaks hardlink.

### DIFF
--- a/end-user/en/source/pages/migration/migration-details.rst
+++ b/end-user/en/source/pages/migration/migration-details.rst
@@ -22,8 +22,8 @@ On the scan target, the ``uforge-scan`` binary is copied and launched as root to
 
 	1. ``uforge-scan`` tests the connection to UForge server with the information provided by the user in the command line.
 	2. ``uforge-scan`` checks the basic information of the machine (Operating System, architecture) and the installation parameters (partitioning, timezone, keyboard, etc.).
-	3. Analysis of the operating system native packages installed on the system. The ``uforge-scan`` binary checks which packages have been installed, the state of the files in these packages etc.  The scan process registers all the metadata (rights, user and groups, checksums).
-	4. Analysis of the files that are not part of any operating system native packages. The ``uforge-scan`` binary registers all the metadata (rights, user and groups, checksums).
+	3. Analysis of the operating system native packages installed on the system. The ``uforge-scan`` binary checks which packages have been installed, the state of the files in these packages etc.  The scan process registers all the metadata (rights, user and groups, checksums, link count).
+	4. Analysis of the files that are not part of any operating system native packages. The ``uforge-scan`` binary registers all the metadata (rights, user and groups, checksums, link count).
 
 .. _migration-process-analysis:
 

--- a/end-user/en/source/pages/migration/whitebox-migration.rst
+++ b/end-user/en/source/pages/migration/whitebox-migration.rst
@@ -35,5 +35,4 @@ Once the scan report has been imported as an appliance template, you can update 
 
 The generation process is slightly different between black box and white box migration. UForge is not generating a machine image from a scan report, rather from an appliance template. You can add and remove packages at will from the OS Profile layer.  Consequently package dependencies are calculated using the list of packages in the OS Profile. Any missing packages from the OS Profile are added prior to generating the machine image.  
 
-.. warning:: UForge restores hard links. But if partitioning has been changed from the original, restoring hard link might be failed (hard links must be in the same partition). In this case, UForge creates copy of the original file.
-
+.. warning:: UForge restores hard links. But if the partitioning table has been updated (and different from the original), restoring one or more hard links may fail (hard links must be in the same partition). In this case, UForge creates copy of the original file.

--- a/end-user/en/source/pages/migration/whitebox-migration.rst
+++ b/end-user/en/source/pages/migration/whitebox-migration.rst
@@ -35,5 +35,5 @@ Once the scan report has been imported as an appliance template, you can update 
 
 The generation process is slightly different between black box and white box migration. UForge is not generating a machine image from a scan report, rather from an appliance template. You can add and remove packages at will from the OS Profile layer.  Consequently package dependencies are calculated using the list of packages in the OS Profile. Any missing packages from the OS Profile are added prior to generating the machine image.  
 
-
+.. warning:: UForge restores hard links. But if partitioning has been changed from the original, restoring hard link might be failed (hard links must be in the same partition). In this case, UForge creates copy of the original file.
 


### PR DESCRIPTION
 - add a warning related to hardlink while wite box migration in case partitining has been changed.