### PR TITLE
Add K5/Windows specific instructions for golden creation and blackbox migration

### DIFF
--- a/admin/en/source/pages/manage-resources/golden-create.rst
+++ b/admin/en/source/pages/manage-resources/golden-create.rst
@@ -13,22 +13,26 @@ To create a new Golden Image, you will need to:
 		* Drive ``C:``
 
 	2. We recommend that you run Windows Update to ensure that the latest updates are pre-installed in the Golden Image.
-	
+
 	3. Optionally, you can also add the following customizations:
 
 		* Modify the registry
 		* Extra software installation
 		* User creation
 
-	4. Optionally, you can free several gigabytes of space by cleaning up windows updates installers. 
+	.. note:: If you plan to deploy generated Windows instances onto `K5 Fujitsu Public Cloud <http://www.fujitsu.com/global/solutions/cloud/k5/>`_, you must retrieve
+		Transport Agent Software from `K5 Support <mailto:FCSK5_GSD@ph.fujitsu.com>`_, and install it. For more detailed information, please refer to
+		`official Fujitsu K5 IaaS Documentation <http://www.fujitsu.com/uk/Images/k5-iaas-features-handbook.pdf>`_.
+
+	4. Optionally, you can free several gigabytes of space by cleaning up windows updates installers.
 
 		.. warning:: After this optimization you may not be able to uninstall some of the Windows updates.
 
-		.. code-block:: shell	
+		.. code-block:: shell
 
 			$ dism /online /Cleanup-Image /StartComponentCleanup /ResetBase
 
-	5. If you have Service Packs installed, you can free up some space by executing the following command, which will merge the Service Pack installer to the operating system. 
+	5. If you have Service Packs installed, you can free up some space by executing the following command, which will merge the Service Pack installer to the operating system.
 
 		.. warning:: After this optimization, you will not be able to uninstall the Service Pack.
 
@@ -49,7 +53,7 @@ To create a new Golden Image, you will need to:
 			.. code-block:: shell
 
 				$ cp --sparse=always image.raw newimage.raw
-        
+
         	This will copy the image file but skip the zeros, so the .raw image will be as sparse as possible, also helping the compression program.
 
 			.. code-block:: shell
@@ -97,10 +101,10 @@ To create a new Golden Image, you will need to:
 		.. code-block:: shell
 
 			$ sysprep.exe /generalize /oobe /shutdown /unattend:c:\path-to-sysprep\Unattend.xml
-	
+
 		.. note:: This will shutdown the machine. Do not boot the machine again!
 
-	10. You can now compress the golden images by running: 
+	10. You can now compress the golden images by running:
 
 		.. code-block:: shell
 
@@ -159,11 +163,11 @@ The following is an example of an unattend file to be used when creating a golde
 		</unattend>
 
 	.. note:: ``<ProductKey>`` element in the unattend file may not be mandatory. Whether the element is necessary or not depends on the type of the installation medium you used for the system. For example, the Volume License media do not require any <ProductKey> element in the unattend file. Please refer to Microsoft's documents for details.
-	
+
 	.. note:: Elements for the locale and the language in the unattend file should have appropriate values in accordance with the language of the target OS. The following example shows the elements and their values for Japanese Windows.
-	
+
 		.. code-block:: shell
-			
+
 			<InputLocale>0411:00000411</InputLocale>
 			<SystemLocale>ja-JP</SystemLocale>
 			<UILanguage>ja-JP</UILanguage>
@@ -226,13 +230,13 @@ The following is an example of an unattend file to be used when creating a golde
 		        </component>
 		    </settings>
 		</unattend>
-	
+
 	.. note:: ``<ProductKey>`` element in the unattend file may not be mandatory. Whether the element is necessary or not depends on the type of the installation medium you used for the system. For example, the Volume License media do not require any <ProductKey> element in the unattend file. Please refer to Microsoft's documents for details.
 
 	.. note:: Elements for the locale and the language in the unattend file should have appropriate values in accordance with the language of the target OS. The following example shows the elements and their values for Japanese Windows.
-	
+
 		.. code-block:: shell
-			
+
 			<InputLocale>0411:00000411</InputLocale>
 			<SystemLocale>ja-JP</SystemLocale>
 			<UILanguage>ja-JP</UILanguage>

--- a/admin/en/source/pages/manage-resources/golden-storing.rst
+++ b/admin/en/source/pages/manage-resources/golden-storing.rst
@@ -21,9 +21,9 @@ So for example:
 
 ``Windows/releases/Server2008R2/x86_64/English/Standard/Core/2012-10-19/Windows_2008R2_Standard_Core_2012-10-19.raw.gz``
 
-.. note:: If you plan to deploy generated Windows instances onto `K5 Fujitsu Public Cloud <http://www.fujitsu.com/global/solutions/cloud/k5/>`_, only `Standard` and `Enterprise` editions are supported.
+.. note:: If you plan to deploy generated Windows instances onto `K5 Fujitsu Public Cloud <http://www.fujitsu.com/global/solutions/cloud/k5/>`_, only "Standard" and "Enterprise" editions are supported.
 
- For convenience, you can use an edition name starting by `Standard` or `Enterprise`. For example: `StandardK5` will be recognized as a `Standard` edition, `EnterpriseMDR` will be recognized as `Enterprise`.
+ For convenience, you can use an edition name starting by "Standard" or "Enterprise". For example: "StandardK5" will be recognized as a "Standard" edition, "EnterpriseMDR" will be recognized as "Enterprise".
 
  For more detailed information, please refer to `official Fujitsu K5 IaaS Documentation <http://www.fujitsu.com/uk/Images/k5-iaas-features-handbook.pdf>`_.
 

--- a/admin/en/source/pages/manage-resources/golden-storing.rst
+++ b/admin/en/source/pages/manage-resources/golden-storing.rst
@@ -7,7 +7,7 @@ Storing Golden Images on the NAS
 
 Each time you have a new Golden Image, you need to store them in the right NAS location.
 
-.. note:: To store the golden images (all profiles in one language) you will need about 40Gb of disk space on the UForge NAS. 
+.. note:: To store the golden images (all profiles in one language) you will need about 40Gb of disk space on the UForge NAS.
 
 The golden images should be stored in::
 
@@ -17,10 +17,15 @@ The path is::
 
 	{Language}/{Edition}/{Type}/{generation date}(YYYY-MM-DD)/goldenImagePathCompressedInGz
 
-So for example: 
+So for example:
 
 ``Windows/releases/Server2008R2/x86_64/English/Standard/Core/2012-10-19/Windows_2008R2_Standard_Core_2012-10-19.raw.gz``
 
+.. note:: If you plan to deploy generated Windows instances onto `K5 Fujitsu Public Cloud <http://www.fujitsu.com/global/solutions/cloud/k5/>`_, only `Standard` and `Enterprise` editions are supported.
+
+ For convenience, you can use an edition name starting by `Standard` or `Enterprise`. For example: `StandardK5` will be recognized as a `Standard` edition, `EnterpriseMDR` will be recognized as `Enterprise`.
+
+ For more detailed information, please refer to `official Fujitsu K5 IaaS Documentation <http://www.fujitsu.com/uk/Images/k5-iaas-features-handbook.pdf>`_.
 
 .. _add-golden-toAppCenter:
 
@@ -29,11 +34,11 @@ Adding a Golden Image to UForge AppCenter
 
 Once you have your Golden Image, you need to add it to your UForge AppCenter in order to be able to use the Windows version to create appliance templates. Your golden image must be in one of the following formats:
 
-	* raw.gz 
-	* raw.zip 
-	* raw.bz2 
+	* raw.gz
+	* raw.zip
+	* raw.bz2
 	* raw.lrz
-	* vdi 
+	* vdi
 	* vhd
 	* vmdk
 
@@ -46,9 +51,9 @@ To add your Golden Image to UForge:
 			$ /tmp/DISTROS/Windows/releases/<windows os version>/x86_64/<language>/<my custom profile name>/<Core|Full>/<YYYY-MM-DD>/golden.xxx
 
 		For example: /tmp/DISTROS/Windows/releases/Server2008R2/x86_64/English/MyProfile/Core/2014- 04-28/Windows_2008R2_English_Datacenter_Core_2014-04-28.raw.gz
-		
-		Note: 
-		
+
+		Note:
+
 			* File and directory ownership should be ``tomcat:tomcat``.
 			* Permissions should be readable for all users
 			* Disk name must be unique in the ``/tmp/DISTORS/Windows`` file tree
@@ -65,7 +70,6 @@ To add your Golden Image to UForge:
 
 		.. note:: The parameters set when running ``org golden create`` should correspond to the path on the NAS, that is: {Language}/{Edition}/{Type}/{generation date}(YYYY-MM-DD)/goldenImagePathCompressedInGz
 
-		For example to install the golden image saved to the following path: ``Windows/releases/Server2008R2/x86_64/English/Standard/Full/2012-10-19/Windows_2008R2_Standard_Full_2012-10-19.raw.gz``, you need to run:: 
+		For example to install the golden image saved to the following path: ``Windows/releases/Server2008R2/x86_64/English/Standard/Full/2012-10-19/Windows_2008R2_Standard_Full_2012-10-19.raw.gz``, you need to run::
 
 		$ org golden create --name Windows --arch x86_64 --version Server2008R2 --language English --edition Standard --type Full --goldenDate 2012-10-19 --goldenName Windows_2008R2_Standard_Full_2012-10-19.raw.gz
-

--- a/end-user/en/source/pages/migration/blackbox-migration.rst
+++ b/end-user/en/source/pages/migration/blackbox-migration.rst
@@ -8,7 +8,7 @@ Blackbox Migration Process
 The goal of black box migration is to reproduce a near identical copy of the currently running workload.  However, there will always be small differences between the two workloads after migration is complete.  When scanning a system the following information is detected:
 
 	* all the files and packages on the system (including configuration information)
-	* network settings including all NICs. Note that if the first card is static, it will be changed to DHCP. 
+	* network settings including all NICs. Note that if the first card is static, it will be changed to DHCP.
 	* root and user password (encrypted)
 	* timezone
 	* keyboard settings
@@ -36,7 +36,15 @@ When you carry out black box migration (by generating a machine image directly f
 		- Apply the overlay file from the scan report
 		- Apply the low configuration information detected in the scan report (passwords, timezone, keyboard, etc)
 		- Apply any specific libraries or configuration depending on the machine image format chosen (e.g for AWS UForge adds the required AWS libraries)
-		
+
 	4. Register the new machine image to the target environment.
 	5. You can provision one or more instances from the machine image. Each instance being a near identical workload from the original.
 
+	.. note:: If you plan migrate a Windows instance onto `K5 Fujitsu Public Cloud <http://www.fujitsu.com/global/solutions/cloud/k5/>`_, you must also (before scanning):
+
+				* Uninstall VMWare Tools (if installed).
+				* Retrieve Transport Agent Software from `K5 Support <mailto:FCSK5_GSD@ph.fujitsu.com>`_.
+				* Install Transport Agent Software.
+				* Uninstall CloudBase-Init (if installed).
+
+				For more detailed information, please refer to `official Fujitsu K5 IaaS Documentation <http://www.fujitsu.com/uk/Images/k5-iaas-features-handbook.pdf>`_.

--- a/end-user/en/source/pages/migration/blackbox-migration.rst
+++ b/end-user/en/source/pages/migration/blackbox-migration.rst
@@ -40,7 +40,7 @@ When you carry out black box migration (by generating a machine image directly f
 	4. Register the new machine image to the target environment.
 	5. You can provision one or more instances from the machine image. Each instance being a near identical workload from the original.
 
-	.. note:: If you plan migrate a Windows instance onto `K5 Fujitsu Public Cloud <http://www.fujitsu.com/global/solutions/cloud/k5/>`_, you must also (before scanning):
+	.. note:: If you plan migrate a Windows instance onto `K5 Fujitsu Public Cloud <http://www.fujitsu.com/global/solutions/cloud/k5/>`_, you must also do the following before scanning:
 
 				* Uninstall VMWare Tools (if installed).
 				* Retrieve Transport Agent Software from `K5 Support <mailto:FCSK5_GSD@ph.fujitsu.com>`_.


### PR DESCRIPTION
For publishing on K5 Windows images, there are some specific steps to do. 
Cf. https://projects.usharesoft.com/issues/6065 and https://projects.usharesoft.com/issues/5954

_Note: I've just noticed that my text editor removed unnecessary spaces. I don't think it's a problem but if you feel so, tell me, I will restore them to avoid confusion._ 