### PR TITLE
Update nic_create.rst

### DIFF
--- a/apis/en/source/pages/applianceinstallprofilenic/nic_create.rst
+++ b/apis/en/source/pages/applianceinstallprofilenic/nic_create.rst
@@ -43,7 +43,7 @@ Example Request
 
 .. code-block:: bash
 
-	curl "https://uforge.example.com/apiusers/{uid}/appliances/{aid}/installProfile/{ipid}/nics" -X POST \
+	curl "https://uforge.example.com/api/users/{uid}/appliances/{aid}/installProfile/{ipid}/nics" -X POST \
 	-u USER_LOGIN:PASSWORD -H "Accept: application/xml" --data-binary "@representation.xml"
 
 Example of representation.xml content (the request body):


### PR DESCRIPTION
Replaced https://uforge.example.com/apiusers/... (erroneous) by https://uforge.example.com/api/users/... (correct).