### PR TITLE
Update nic_delete.rst

### DIFF
--- a/apis/en/source/pages/applianceinstallprofilenic/nic_delete.rst
+++ b/apis/en/source/pages/applianceinstallprofilenic/nic_delete.rst
@@ -40,7 +40,7 @@ Example Request
 
 .. code-block:: bash
 
-	curl "https://uforge.example.com/apiusers/{uid}/appliances/{aid}/installProfile/{ipid}/nics/{nid}" -X DELETE \
+	curl "https://uforge.example.com/api/users/{uid}/appliances/{aid}/installProfile/{ipid}/nics/{nid}" -X DELETE \
 	-u USER_LOGIN:PASSWORD -H "Accept: application/xml"
 
 .. seealso::


### PR DESCRIPTION
Replaced https://uforge.example.com/apiusers/... (erroneous) by https://uforge.example.com/api/users/... (correct).