### PR TITLE
Update nic_get.rst

### DIFF
--- a/apis/en/source/pages/applianceinstallprofilenic/nic_get.rst
+++ b/apis/en/source/pages/applianceinstallprofilenic/nic_get.rst
@@ -40,7 +40,7 @@ Example Request
 
 .. code-block:: bash
 
-	curl "https://uforge.example.com/apiusers/{uid}/appliances/{aid}/installProfile/{ipid}/nics/{nid}" -X GET \
+	curl "https://uforge.example.com/api/users/{uid}/appliances/{aid}/installProfile/{ipid}/nics/{nid}" -X GET \
 	-u USER_LOGIN:PASSWORD -H "Accept: application/xml"
 
 .. seealso::


### PR DESCRIPTION
Replaced https://uforge.example.com/apiusers/... (erroneous) by https://uforge.example.com/api/users/... (correct).