### PR TITLE
Update nic_getAll.rst

### DIFF
--- a/apis/en/source/pages/applianceinstallprofilenic/nic_getAll.rst
+++ b/apis/en/source/pages/applianceinstallprofilenic/nic_getAll.rst
@@ -43,7 +43,7 @@ Example Request
 
 .. code-block:: bash
 
-	curl "https://uforge.example.com/apiusers/{uid}/appliances/{aid}/installProfile/{ipid}/nics" -X GET \
+	curl "https://uforge.example.com/api/users/{uid}/appliances/{aid}/installProfile/{ipid}/nics" -X GET \
 	-u USER_LOGIN:PASSWORD -H "Accept: application/xml"
 
 .. seealso::


### PR DESCRIPTION
Replaced https://uforge.example.com/apiusers/... (erroneous) by https://uforge.example.com/api/users/... (correct).