### PR TITLE
Update nic_updateList.rst

### DIFF
--- a/apis/en/source/pages/applianceinstallprofilenic/nic_updateList.rst
+++ b/apis/en/source/pages/applianceinstallprofilenic/nic_updateList.rst
@@ -41,7 +41,7 @@ Example Request
 
 .. code-block:: bash
 
-	curl "https://uforge.example.com/apiusers/{uid}/appliances/{aid}/installProfile/{ipid}/nics" -X PUT \
+	curl "https://uforge.example.com/api/users/{uid}/appliances/{aid}/installProfile/{ipid}/nics" -X PUT \
 	-u USER_LOGIN:PASSWORD -H "Accept: application/xml" --data-binary "@representation.xml"
 
 Example of representation.xml content (the request body):


### PR DESCRIPTION
Replaced https://uforge.example.com/apiusers/... (erroneous) by https://uforge.example.com/api/users/... (correct).