### PR TITLE
update release notes to change the release date because of the delay

### DIFF
--- a/admin/en/source/pages/changelog.rst
+++ b/admin/en/source/pages/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 3.7.fp6
 -------
 
-Release Date: 2017-07-24
+Release Date: 2017-07-25
 
 New Features
 ~~~~~~~~~~~~

--- a/apis/en/source/pages/changelog.rst
+++ b/apis/en/source/pages/changelog.rst
@@ -2,10 +2,11 @@
 
 Changelog
 =========
+
 3.7.fp6
 -------
 
-Release Date: 2017-07-24
+Release Date: 2017-07-25
 
 New Features
 ~~~~~~~~~~~~

--- a/end-user/en/source/pages/changelog.rst
+++ b/end-user/en/source/pages/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 3.7.fp6
 -------
 
-Release Date: 2017-07-24
+Release Date: 2017-07-25
 
 New Features
 ~~~~~~~~~~~~


### PR DESCRIPTION
  The original release date was July 24, but USS decided to change the date
  to July 25 because of a delay in fixing an issue.