### PR TITLE
Complete blackbox migration doc for Azure image.

### DIFF
--- a/end-user/en/source/pages/migration/blackbox-migration.rst
+++ b/end-user/en/source/pages/migration/blackbox-migration.rst
@@ -32,10 +32,12 @@ When you generate a machine image from the scan, all the information included in
 
 	For more detailed information, please refer to `official Fujitsu K5 IaaS Documentation <http://www.fujitsu.com/uk/Images/k5-iaas-features-handbook.pdf>`_.
 
-.. note:: Currently, publications to Microsoft Azure platform <https://azure.microsoft.com/en-us/>`_ require to install WALinuxAgent 2.0.18 (for CentOS) or waagent 2.0.16 (for Debian and Ubuntu) which are not compatible with NetworkManager (or network-manager) package. Therefore, if you plan to migrate, you must also do the following before scanning:
+.. note:: Currently, publications to Microsoft Azure platform `<https://azure.microsoft.com/en-us/>`_ require to install WALinuxAgent 2.0.18 (for CentOS) or waagent 2.0.16 (for Debian and Ubuntu) which are not compatible with NetworkManager (or network-manager) package. Therefore, if you plan to migrate, you must also do the following before scanning:
 
 	1. Uninstall NetworkManager (if installed).
 	2. Uninstall the Microsoft Azure agent, i.e. WALinuxAgent and waagent packages (if installed).
+
+.. warning:: Ubuntu 14.04 migration for Microstoft Azure target platform is not supported by UForge.
 
 When you carry out black box migration (by generating a machine image directly from a scan), the following steps are carried out:
 

--- a/end-user/en/source/pages/migration/blackbox-migration.rst
+++ b/end-user/en/source/pages/migration/blackbox-migration.rst
@@ -32,7 +32,7 @@ When you generate a machine image from the scan, all the information included in
 
 	For more detailed information, please refer to `official Fujitsu K5 IaaS Documentation <http://www.fujitsu.com/uk/Images/k5-iaas-features-handbook.pdf>`_.
 
-.. note:: If you plan to migrate a Linux instance onto `Microsoft Azure Cloud <https://azure.microsoft.com/en-us/>`_, you must also do the following before scanning:
+.. note:: Currently, publications to Microsoft Azure platform <https://azure.microsoft.com/en-us/>`_ require to install WALinuxAgent 2.0.18 (for CentOS) or waagent 2.0.16 (for Debian and Ubuntu) which are not compatible with NetworkManager package. Therefore, if you plan to migrate, you must also do the following before scanning:
 
 	1. Uninstall NetworkManager (if installed).
 	2. Uninstall the Microsoft Azure agent, i.e. WALinuxAgent and waagent packages (if installed).

--- a/end-user/en/source/pages/migration/blackbox-migration.rst
+++ b/end-user/en/source/pages/migration/blackbox-migration.rst
@@ -32,7 +32,7 @@ When you generate a machine image from the scan, all the information included in
 
 	For more detailed information, please refer to `official Fujitsu K5 IaaS Documentation <http://www.fujitsu.com/uk/Images/k5-iaas-features-handbook.pdf>`_.
 
-.. note:: Currently, publications to Microsoft Azure platform <https://azure.microsoft.com/en-us/>`_ require to install WALinuxAgent 2.0.18 (for CentOS) or waagent 2.0.16 (for Debian and Ubuntu) which are not compatible with NetworkManager package. Therefore, if you plan to migrate, you must also do the following before scanning:
+.. note:: Currently, publications to Microsoft Azure platform <https://azure.microsoft.com/en-us/>`_ require to install WALinuxAgent 2.0.18 (for CentOS) or waagent 2.0.16 (for Debian and Ubuntu) which are not compatible with NetworkManager (or network-manager) package. Therefore, if you plan to migrate, you must also do the following before scanning:
 
 	1. Uninstall NetworkManager (if installed).
 	2. Uninstall the Microsoft Azure agent, i.e. WALinuxAgent and waagent packages (if installed).

--- a/end-user/en/source/pages/migration/blackbox-migration.rst
+++ b/end-user/en/source/pages/migration/blackbox-migration.rst
@@ -32,6 +32,11 @@ When you generate a machine image from the scan, all the information included in
 
 	For more detailed information, please refer to `official Fujitsu K5 IaaS Documentation <http://www.fujitsu.com/uk/Images/k5-iaas-features-handbook.pdf>`_.
 
+.. note:: If you plan to migrate a Linux instance onto `Microsoft Azure Cloud <https://azure.microsoft.com/en-us/>`_, you must also do the following before scanning:
+
+	1. Uninstall NetworkManager (if installed).
+	2. Uninstall the Microsoft Azure agent, i.e. WALinuxAgent and waagent packages (if installed).
+
 When you carry out black box migration (by generating a machine image directly from a scan), the following steps are carried out:
 
 	1. You are prompted to indicate if you want to change the overall disk size.

--- a/end-user/en/source/pages/templating/supported-os.rst
+++ b/end-user/en/source/pages/templating/supported-os.rst
@@ -143,7 +143,7 @@ With UForge you can create machine images in the following formats.
 +-------------------------------------+-------------------------------------------------------+
 | Amazon AWS                          | none                                                  |
 +-------------------------------------+-------------------------------------------------------+
-| Azure Resource Manager              | none                                                  |
+| Azure Resource Manager              | Ubuntu <= 12.04 not supported                         |
 +-------------------------------------+-------------------------------------------------------+
 | Cloudstack                          | Target formats:                                       |
 |                                     | CloudStack VMWare (OVA)                               |


### PR DESCRIPTION
Publications to Microsoft Azure platform require to install WALinuxAgent 2.0.18 (for CentOS) or waagent 2.0.16 (for Debian and Ubuntu) which are not compatible with NetworkManager package.