### PR TITLE
Add RHEL limitation for K5 target format into documentation

### DIFF
--- a/end-user/en/source/pages/templating/supported-os.rst
+++ b/end-user/en/source/pages/templating/supported-os.rst
@@ -159,7 +159,7 @@ With UForge you can create machine images in the following formats.
 |                                     | Flexiant OVA - VMWare                                 |
 |                                     | Flexiant QCOW2 - KVM/Xen/VMWare                       |
 +-------------------------------------+-------------------------------------------------------+
-| Fujitsu K5                          | RedHat Enterprise Linux not supported                 |
+| Fujitsu K5                          | Red Hat Enterprise Linux not supported                |
 +-------------------------------------+-------------------------------------------------------+
 | Google Compute Engine               | none                                                  |
 +-------------------------------------+-------------------------------------------------------+

--- a/end-user/en/source/pages/templating/supported-os.rst
+++ b/end-user/en/source/pages/templating/supported-os.rst
@@ -159,7 +159,7 @@ With UForge you can create machine images in the following formats.
 |                                     | Flexiant OVA - VMWare                                 |
 |                                     | Flexiant QCOW2 - KVM/Xen/VMWare                       |
 +-------------------------------------+-------------------------------------------------------+
-| Fujitsu K5                          | none                                                  |
+| Fujitsu K5                          | RedHat Enterprise Linux not supported                 |
 +-------------------------------------+-------------------------------------------------------+
 | Google Compute Engine               | none                                                  |
 +-------------------------------------+-------------------------------------------------------+


### PR DESCRIPTION
As UForge does not yet support K5 target format for RedHat Enterprise Linux
based images, it must be precised in documentation