### PR TITLE
add a warning on how to work with sysprep

### DIFF
--- a/end-user/en/source/pages/templating/appliance-installprofile.rst
+++ b/end-user/en/source/pages/templating/appliance-installprofile.rst
@@ -81,3 +81,5 @@ You can define the following as part of a Windows-based appliance install profil
 * ``Welcome Message``: You can enter a welcome message.
 
 	.. image:: /images/install-profile-windowsfp3.png
+
+.. warning:: For now, please do not select to run sysprep, if the target cloud platform injects CloudBase-Init during its import process, for example, on K5. If you want to run sysprep, run sysprep after the import process has finished.


### PR DESCRIPTION
This warning gives users the instruction on how to work with sysprep, especially when cloudbase-init is injected by the target platform. In mid- and long-term, the issue will be fixed programatically. For now, users are advised not to run sysprep by UForge to avoid possible conflicts with cloudbase-init.