### PR TITLE
Added information regarding GRUB2 core.img size

### DIFF
--- a/end-user/en/source/pages/migration/source-target-diffs.rst
+++ b/end-user/en/source/pages/migration/source-target-diffs.rst
@@ -109,6 +109,5 @@ In addition to the above, there are other minor differences between source and t
 GRUB2 Core Image
 ~~~~~~~~~~~~~~~~
 
-GRUB2 is always re-installed when migrating a Linux system.
-Thus, some files in the folder ``/boot/grub2`` might be different between source and target.
+GRUB2 is always re-installed when migrating a Linux system. Therefore, some files in the folder ``/boot/grub2`` might be different between source and target.
 This is especially true for ``/boot/grub2/i386-pc/core.img`` since UForge installs GRUB2, regardless of the source machine configuration, with the following modules: ``biosdisk linux boot part_msdos lvm ext2 gettext xfs``.

--- a/end-user/en/source/pages/migration/source-target-diffs.rst
+++ b/end-user/en/source/pages/migration/source-target-diffs.rst
@@ -104,3 +104,11 @@ Red Hat vs CentOS Packages
 In addition to the above, there are other minor differences between source and target instances after migration. If CentOS packages have been installed on a Red Hat server, with the same functionality and the same version number as equivalent existing Red Hat packages, then after migration, these CentOS packages will be replaced by their Red Hat counterparts, because the vendor information present in RPM packages is not accounted for during migration: only the package name and version number are.
 
 .. warning:: Installing non-Red Hat packages on a Red Hat server, or replacing Red Hat packages by CentOS packages, is strongly discouraged, because it voids the warranty. Red Hat can refuse support requests on a modified machine.
+
+
+GRUB2 Core Image
+~~~~~~~~~~~~~~~~
+
+GRUB2 is always re-installed when migrating a Linux system.
+Thus, some files in the folder ``/boot/grub2`` might be different between source and target.
+This is especially true for ``/boot/grub2/i386-pc/core.img`` since UForge installs GRUB2, regardless of the source machine configuration, with the following modules: ``biosdisk linux boot part_msdos lvm ext2 gettext xfs``.

--- a/end-user/en/source/pages/migration/source-target-diffs.rst
+++ b/end-user/en/source/pages/migration/source-target-diffs.rst
@@ -106,8 +106,8 @@ In addition to the above, there are other minor differences between source and t
 .. warning:: Installing non-Red Hat packages on a Red Hat server, or replacing Red Hat packages by CentOS packages, is strongly discouraged, because it voids the warranty. Red Hat can refuse support requests on a modified machine.
 
 
-GRUB2 Core Image
-~~~~~~~~~~~~~~~~
+GRUB2
+~~~~~
 
 GRUB2 is always re-installed when migrating a Linux system. Therefore, some files in the folder ``/boot/grub2`` might be different between source and target.
 This is especially true for ``/boot/grub2/i386-pc/core.img`` since UForge installs GRUB2, regardless of the source machine configuration, with the following modules: ``biosdisk linux boot part_msdos lvm ext2 gettext xfs``.


### PR DESCRIPTION
- This explains why the file size is different between the source machine and the target machine