### PR TITLE
Add Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: C
+cache: pip
+install:
+    - pip install --user sphinx
+    - pip install --user sphinx_rtd_theme
+    - pip install --user rst2pdf
+script: make htmlwerror


### PR DESCRIPTION
- Travis will try to build html treating warnings as errors. This should ensure that we no longer have warnings when generating the doc.