### PR TITLE
Fix to handle "uForge API" directory name

### DIFF
--- a/venv.sh
+++ b/venv.sh
@@ -58,7 +58,7 @@ function copy-uforge-api() {
         cp -v $UFORGE_DIR/uForgeRest/target/wadl/uforge.xsd $BASEDIR/apis/en/source/pages/dto-objects/
         cp -v $UFORGE_DIR/uForgeRest/target/wadl/application.wadl $BASEDIR/apis/en/source/pages/
         UFORGE_API_DIR=$(find $UFORGE_DIR/uForgeRest/target/xslt -type d -name 'uForge API')
-        cp -r $UFORGE_API_DIR/index.rst $UFORGE_API_DIR/pages $BASEDIR/apis/en/source/
+        cp -r "$UFORGE_API_DIR/index.rst" "$UFORGE_API_DIR/pages" $BASEDIR/apis/en/source/
         cp -v $UFORGE_DIR/UForgeAPI/target/xslt/dto/*.rst $BASEDIR/apis/en/source/pages/dto-objects
 
         echo "Fixing the generated index.rst to add the missing label for end-user doc if needed..."


### PR DESCRIPTION
- Add double quotes arround the path to avoid error due to the space inside "uForge API"