### PR TITLE
Indicate new Azure agent version for Debian in release note

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -12,6 +12,11 @@ New Features
 ~~~~~~~~~~~~
 * Ability to generate a software component to a Docker image. The user can select any Linux distribution as a "Base OS".
 
+Enhancements
+~~~~~~~~~~~~
+* UForge Microsoft Azure images now use the Azure agent version 2.2.14-1 for Debian 8 (Jessie)
+* UForge Microsoft Azure images now use the Azure agent version 2.2.18-3 for Debian 9 (Stretch)
+
 
 3.8.fp8
 -------


### PR DESCRIPTION
- Azure agent version 2.2.14-1 for Debian 8
- Azure agent version 2.2.18-3 for Debian 9