### PR TITLE
Fixed sphinx version to use latest sphinx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==1.7.8
+sphinx
 rst2pdf
 sphinx_rtd_theme


### PR DESCRIPTION
No longer pinning sphinx to 1.7.8 which doesn't work anymore